### PR TITLE
Fix whitenoise

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ RUN apk add --no-cache --virtual .build-deps \
 COPY . /srv/racedb
 WORKDIR /srv/racedb
 ENV DJANGO_SETTINGS_MODULE=racedb.settings.settings
+ENV SETTINGS=prod
 COPY racedb/secrets.py.sample racedb/secrets.py
 RUN python manage.py collectstatic --noinput && rm racedb/secrets.py


### PR DESCRIPTION
Add SETTINGS envar to Dockerfileensure so that whitenoise is used when collectstatic runs and we get assets with the hash appended in /static/.