### PR TITLE
feat(admin): add action to delete all results from events. Fixes #67

### DIFF
--- a/racedbapp/admin.py
+++ b/racedbapp/admin.py
@@ -37,11 +37,26 @@ class DistanceAdmin(admin.ModelAdmin):
 admin.site.register(Race)
 
 
+def delete_all_results_for_event(modeladmin, request, queryset):
+    from .models import Result
+
+    event_ids = queryset.values_list("id", flat=True).distinct()
+    count = 0
+    for event_id in event_ids:
+        deleted, _ = Result.objects.filter(event_id=event_id).delete()
+        count += deleted
+    modeladmin.message_user(request, f"Deleted {count} results for selected events.")
+
+
+delete_all_results_for_event.short_description = "Delete all results for selected events"
+
+
 @admin.register(Event)
 class EventAdmin(admin.ModelAdmin):
     list_display = ("id", "date", "race", "distance", "city", "flickrsetid")
     search_fields = ("date", "race__name", "distance__name")
     ordering = ("-date",)
+    actions = [delete_all_results_for_event]
 
 
 @admin.register(Result)

--- a/racedbapp/tests/admin/test_admin_delete_all_results.py
+++ b/racedbapp/tests/admin/test_admin_delete_all_results.py
@@ -1,0 +1,43 @@
+import pytest
+
+from racedbapp.admin import delete_all_results_for_event
+from racedbapp.models import Event, Result
+
+
+class DummyRequest:
+    def __init__(self, user):
+        self.user = user
+        self._messages = []
+
+    def _get_messages(self):
+        return self._messages
+
+    def __getattr__(self, name):
+        return None
+
+
+class DummyModelAdmin:
+    def __init__(self):
+        self.messages = []
+
+    def message_user(self, request, message):
+        self.messages.append(message)
+
+
+@pytest.mark.django_db
+def test_delete_all_results_for_event(create_category, create_event, create_result):
+    """
+    Test deleting all results for a specific event.
+    This test creates a category, two events, and two results,
+    then deletes results for one of the events and checks that only one result remains."""
+    category = create_category()
+    event1 = create_event(name_suffix="a")
+    event2 = create_event(name_suffix="b")
+    create_result(category=category, event=event1)
+    create_result(category=category, event=event2)
+    assert Result.objects.count() == 2
+    queryset = Event.objects.filter(id=event1.id)
+    modeladmin = DummyModelAdmin()
+    request = DummyRequest(user=None)
+    delete_all_results_for_event(modeladmin, request, queryset)
+    assert Result.objects.count() == 1


### PR DESCRIPTION
This adds a custom action in the Event admin that allows you to select one or more events and execute "Delete all results for selected events".

![image](https://github.com/user-attachments/assets/724df931-f5fd-489e-8231-d92918e94a0e)
