### PR TITLE
chore: add db backup monitoring cron job. Fixes #71

### DIFF
--- a/deploy/aws/backup_monitor.sh
+++ b/deploy/aws/backup_monitor.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# log output to systemd journal
+exec > >(systemd-cat -t backup_monitor) 2>&1
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <bucket-name> <object-key>"
+  exit 1
+fi
+
+BUCKET="$1"
+KEY="$2"
+
+HEAD_OBJECT_JSON=$(aws s3api head-object --bucket "$BUCKET" --key "$KEY")
+LAST_MODIFIED=$(echo "$HEAD_OBJECT_JSON" | jq -r '.LastModified')
+SIZE=$(echo "$HEAD_OBJECT_JSON" | jq -r '.ContentLength')
+
+if [ -z "$LAST_MODIFIED" ] || [ -z "$SIZE" ]; then
+  echo "Error: Could not retrieve LastModified or ContentLength for s3://$BUCKET/$KEY"
+  exit 2
+fi
+
+LAST_MODIFIED_EPOCH=$(date -d "$LAST_MODIFIED" +%s)
+NOW_EPOCH=$(date +%s)
+AGE=$((NOW_EPOCH - LAST_MODIFIED_EPOCH))
+
+echo "{\"task\": \"backup_monitor\", \"db\": \"mariadb\", \"backup_age_seconds\": $AGE, \"backup_size_bytes\": $SIZE}"

--- a/deploy/aws/deploy_rrw.sh
+++ b/deploy/aws/deploy_rrw.sh
@@ -68,4 +68,7 @@ echo '* * * * * /srv/racedb/deploy/helm/autoupgrade.sh' | crontab -
 # add backup cron job (hourly on the 12th minute)
 (crontab -l 2>/dev/null; echo '12 * * * * /srv/racedb/deploy/aws/backup_to_s3.sh') | crontab -
 
+# add backup monitor cron job (every 15 minutes)
+(crontab -l 2>/dev/null; echo "*/15 * * * * /srv/racedb/deploy/aws/backup_monitor.sh $BUCKET database_backup/racedb.latest.sql.gz") | crontab -
+
 echo "SUCCESS: deploy_rrw.sh completed"


### PR DESCRIPTION
This doesn't do anything for the front end, but it does help us know that backups of the database are happening. We should get a Slack alert in #rrw-alerts if there's a problem.

This is early work in support of a secret plan to reduce some of the new RRW hosting costs in 2026.