### PR TITLE
feat(event): allow sequel URLs. Fixes #93

### DIFF
--- a/racedbapp/shared/shared.py
+++ b/racedbapp/shared/shared.py
@@ -513,7 +513,10 @@ def set_distance_display_name(distance, sequel):
     """Set display_name attribute on a Distance instance based on sequel."""
     if sequel:
         display_name = sequel.name
+        sequel_slug = sequel.slug
     else:
         display_name = distance.name
+        sequel_slug = None
     setattr(distance, "display_name", display_name)
+    setattr(distance, "sequel_slug", sequel_slug)
     return distance

--- a/racedbapp/templates/racedbapp/index_last-race-standard.html
+++ b/racedbapp/templates/racedbapp/index_last-race-standard.html
@@ -7,7 +7,12 @@
       <ul class="pagination">
         {% for i in distances %}
           <li>
-            <a href="{% url 'event' recap_event.date.year recap_event.race.slug i.slug %}">
+            {% if i.sequel_slug %}
+              {% url 'event' recap_event.date.year recap_event.race.slug i.slug i.sequel_slug as event_url %}
+            {% else %}
+              {% url 'event' recap_event.date.year recap_event.race.slug i.slug as event_url %}
+            {% endif %}
+            <a href="{{ event_url }}">
               {% if forloop.first %}
                 <strong>{{ i.display_name }}</strong>
               {% else %}

--- a/racedbapp/tests/views/test_view_event.py
+++ b/racedbapp/tests/views/test_view_event.py
@@ -15,7 +15,6 @@ def test_event_endpoint_success(create_event):
 
 
 @pytest.mark.django_db
-@pytest.mark.django_db
 def test_event_endpoint_missing():
     client = APIClient()
     url = "/event/2025/fake-race/fake-event/"
@@ -23,6 +22,7 @@ def test_event_endpoint_missing():
     assert response.status_code == 404
 
 
+@pytest.mark.django_db
 def test_event_endpoint_sequel(create_event, create_sequel):
     client = APIClient()
     sequel = create_sequel()

--- a/racedbapp/tests/views/test_view_event.py
+++ b/racedbapp/tests/views/test_view_event.py
@@ -15,11 +15,21 @@ def test_event_endpoint_success(create_event):
 
 
 @pytest.mark.django_db
+@pytest.mark.django_db
 def test_event_endpoint_missing():
     client = APIClient()
     url = "/event/2025/fake-race/fake-event/"
     response = client.get(url)
     assert response.status_code == 404
+
+
+def test_event_endpoint_sequel(create_event, create_sequel):
+    client = APIClient()
+    sequel = create_sequel()
+    event = create_event(sequel=sequel)
+    url = f"/event/{event.date.year}/{event.race.slug}/{event.distance.slug}/{event.sequel.slug}/"
+    response = client.get(url)
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db

--- a/racedbapp/urls.py
+++ b/racedbapp/urls.py
@@ -62,6 +62,11 @@ urlpatterns = [
         name="event_team",
     ),
     re_path(
+        r"^event/(?P<year>[0-9]{4})/(?P<race_slug>.*)/(?P<distance_slug>.*)/(?P<sequel_slug>(?!team$)[^/]+)/$",
+        view_event.index,
+        name="event",
+    ),
+    re_path(
         r"^event/(?P<year>[0-9]{4})/(?P<race_slug>.*)/(?P<distance_slug>.*)/$",
         view_event.index,
         name="event",

--- a/racedbapp/view_event.py
+++ b/racedbapp/view_event.py
@@ -15,7 +15,7 @@ from django.db.models import (
     When,
 )
 from django.http import Http404, HttpResponse
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 
 import racedbapp.shared.endurrun
 from racedbapp.shared.types import Choice, Filter
@@ -31,6 +31,7 @@ from .models import (
     Prime,
     Relay,
     Result,
+    Sequel,
     Series,
     Split,
     Wheelchairresult,
@@ -40,14 +41,21 @@ from .shared import shared, utils
 named_split = namedtuple("ns", ["split_num", "split_time"])
 
 
-def index(request, year, race_slug, distance_slug):
+def index(request, year, race_slug, distance_slug, sequel_slug=None):
     qstring = parse.parse_qs(request.META["QUERY_STRING"])
     page = get_page(qstring)
     category = get_category(qstring)
     division = get_division(qstring)
+    if sequel_slug:
+        sequel = get_object_or_404(Sequel, slug=sequel_slug)
+    else:
+        sequel = None
     try:
         event = Event.objects.select_related().get(
-            race__slug=race_slug, distance__slug=distance_slug, date__icontains=year
+            race__slug=race_slug,
+            distance__slug=distance_slug,
+            date__icontains=year,
+            sequel=sequel,
         )
     except Exception:
         raise Http404("Matching event not found")


### PR DESCRIPTION
This addresses a couple things:

1. Distance links in the index recap section now link to the correct URL if the event is a sequel.
2. The event view itself will no longer 404 for an event that has a sequel (for both bare and sequeled event).

The event view (and others) still have many other changes that have to happen. But they are out of scope of this change.