### PR TITLE
fix: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   semantic-pr:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
Potential fix for [https://github.com/runwaterloo/racedb/security/code-scanning/1](https://github.com/runwaterloo/racedb/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job that limits the GITHUB_TOKEN permissions to only those required. For the `amannn/action-semantic-pull-request` action, the minimal required permissions are typically `contents: read` (to read repository contents) and `pull-requests: write` (to comment or update status on pull requests). The best way to fix this is to add the following block under the job definition (`semantic-pr`) in `.github/workflows/pr-title-lint.yml`:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This should be placed directly under the job name, before `runs-on`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
