### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,6 @@
 name: Integration Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/runwaterloo/racedb/security/code-scanning/2](https://github.com/runwaterloo/racedb/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the GITHUB_TOKEN. Since the workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` field and before the `on` block. This will apply the permission restriction to all jobs in the workflow unless overridden at the job level. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
