### PR TITLE
fix: Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   autoupdate:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/runwaterloo/racedb/security/code-scanning/3](https://github.com/runwaterloo/racedb/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the required permissions for the GITHUB_TOKEN. Since the workflow creates a pull request with changes, it needs `contents: write` (to push changes) and `pull-requests: write` (to open a PR). The best practice is to set these permissions at the job level (for `autoupdate`), unless other jobs in the workflow also need them. The change should be made by adding the following block under the `autoupdate:` job definition (after line 9):

```yaml
permissions:
  contents: write
  pull-requests: write
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
