### PR TITLE
feat: removeSimlink create better fallback

### DIFF
--- a/racedbapp/static/race_logos/401.png
+++ b/racedbapp/static/race_logos/401.png
@@ -1,1 +1,0 @@
-rw-race-logo.png

--- a/racedbapp/templatetags/racedbapp_extras.py
+++ b/racedbapp/templatetags/racedbapp_extras.py
@@ -4,6 +4,7 @@ from django import template
 from django.templatetags.static import static
 
 from ..models import Config, Distance
+from ..shared.utils import get_race_logo_slug
 
 register = template.Library()
 
@@ -114,4 +115,5 @@ def get_default_record_distance_slug(string):
 def event_logo(event):
     if getattr(event, "custom_logo_url", None):
         return event.custom_logo_url
-    return static(f"race_logos/{event.race.slug}.png")
+    safe_slug = get_race_logo_slug(event.race.slug)
+    return static(f"race_logos/{safe_slug}.png")

--- a/racedbapp/tests/shared/test_utils.py
+++ b/racedbapp/tests/shared/test_utils.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from racedbapp.shared.utils import get_achievement_image
+from racedbapp.shared.utils import get_achievement_image, get_race_logo_slug
 
 
 def test_get_achievement_image_file_exists():
@@ -13,3 +13,18 @@ def test_get_achievement_image_file_missing():
     with patch("racedbapp.shared.utils.Path.is_file", return_value=False):
         result = get_achievement_image("slug", "badge")
         assert result == "generic_100x100.png"
+
+
+def test_get_race_logo_slug_file_exists():
+    with patch("racedbapp.shared.utils.Path.is_file", return_value=True):
+        assert get_race_logo_slug("baden-road-races") == "baden-road-races"
+
+
+def test_get_race_logo_slug_file_missing():
+    with patch("racedbapp.shared.utils.Path.is_file", return_value=False):
+        assert get_race_logo_slug("does-not-exist") == "rw-race-logo"
+
+
+def test_get_race_logo_slug_non_string_slug():
+    assert get_race_logo_slug(None) == "rw-race-logo"
+    assert get_race_logo_slug(401) == "rw-race-logo"

--- a/racedbapp/tests/templatetags/test_racedbapp_extras.py
+++ b/racedbapp/tests/templatetags/test_racedbapp_extras.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 
@@ -33,8 +34,22 @@ def test_round_up_none():
 
 
 @pytest.mark.django_db
-def test_event_logo(create_event):
+def test_event_logo_uses_race_slug_when_file_exists(create_event):
     event = create_event()
-    assert event_logo(event) == "/static/race_logos/test-race-a.png"
+    with patch("racedbapp.shared.utils.Path.is_file", return_value=True):
+        assert event_logo(event) == "/static/race_logos/test-race-a.png"
+
+
+@pytest.mark.django_db
+def test_event_logo_falls_back_when_file_missing(create_event):
+    event = create_event()
+    with patch("racedbapp.shared.utils.Path.is_file", return_value=False):
+        assert event_logo(event) == "/static/race_logos/rw-race-logo.png"
+
+
+@pytest.mark.django_db
+def test_event_logo_prefers_custom_logo_url(create_event):
+    event = create_event()
     event.custom_logo_url = "http://example.com/logo.png"
-    assert event_logo(event) == "http://example.com/logo.png"
+    with patch("racedbapp.shared.utils.Path.is_file", return_value=False):
+        assert event_logo(event) == "http://example.com/logo.png"


### PR DESCRIPTION
Reuses the safe way to get event logos such that if we add new events we don't need to simlink pictures anymore.