### PR TITLE
fix: run DB migrations on deploy and harden event view against bad data

### DIFF
--- a/deploy/helm/templates/job-migrate.yaml
+++ b/deploy/helm/templates/job-migrate.yaml
@@ -1,0 +1,89 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ include "racedb.fullname" . }}-migrate-{{ .Release.Revision }}"
+  labels:
+    {{- include "racedb.labels" . | nindent 4 }}
+    app.kubernetes.io/task: migrate
+  annotations:
+    # Run database migrations before the new pods roll out, so the new image
+    # never serves traffic against a schema it expects but the DB lacks.
+    "helm.sh/hook": pre-upgrade,pre-install
+    "helm.sh/hook-weight": "-5"
+    # Keep a failed Job around for inspection; replace it on the next deploy.
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        {{- include "racedb.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/task: migrate
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "racedb.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "manage.py", "migrate", "--noinput"]
+          env:
+            - name: CHART
+              value: {{ .Chart.Version }}
+            - name: BUILD
+              value: {{ .Values.image.tag | quote }}
+            - name: DJANGO_SETTINGS_MODULE
+              value: "racedb.settings.settings"
+            - name: WEBHOST
+              value: {{ .Values.ingress.host }}
+            - name: STORAGE
+              value: {{ .Values.racedb.storage }}
+            - name: SETTINGS
+              value: {{ .Values.racedb.settings }}
+            - name: DATABASE
+              value: "postgres"
+            {{- if eq .Values.racedb.settings "dev" }}
+            - name: DEBUG
+              value: "true"
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.racedb.mountLocal }}
+            - mountPath: /srv/racedb
+              name: racedb
+            {{- end }}
+            - mountPath: /srv/racedb/racedb/secrets.py
+              name: racedb-secrets
+            - mountPath: /root/google_service_account.json
+              name: racedb-google-service-account
+      volumes:
+        {{- if .Values.racedb.mountLocal }}
+        - name: racedb
+          hostPath:
+            path: {{ .Values.racedb.devVolumePath }}
+        {{- end }}
+        - name: racedb-secrets
+          hostPath:
+            path: "{{ .Values.racedb.secretsVolumePath }}/secrets.py"
+        - name: racedb-google-service-account
+          hostPath:
+            path: "{{ .Values.racedb.secretsVolumePath }}/google_service_account.json"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/racedbapp/tests/views/test_view_event.py
+++ b/racedbapp/tests/views/test_view_event.py
@@ -3,7 +3,7 @@ import types
 import pytest
 from rest_framework.test import APIClient
 
-from racedbapp.models import Result
+from racedbapp.models import Result, Series
 from racedbapp.shared.types import Filter
 from racedbapp.view_event import (
     annotate_isrwfirst,
@@ -20,6 +20,28 @@ def test_event_endpoint_success(create_event):
     url = f"/event/{event.date.year}/{event.race.slug}/{event.distance.slug}/"
     response = client.get(url)
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_event_endpoint_malformed_series_event_ids(create_event):
+    """A Series with blank/non-numeric tokens in event_ids must not 500 the event page.
+
+    Before hardening, ``int("")`` on an empty token (e.g. a trailing comma)
+    raised ValueError, taking down every event page since the view scans all
+    series. The valid id should still link the series despite the junk tokens.
+    """
+    client = APIClient()
+    event = create_event()
+    Series.objects.create(
+        year=event.date.year,
+        name="Malformed Series",
+        slug="malformed-series",
+        event_ids=f"{event.id}, ,notanumber",
+    )
+    url = f"/event/{event.date.year}/{event.race.slug}/{event.distance.slug}/"
+    response = client.get(url)
+    assert response.status_code == 200
+    assert b"malformed-series" in response.content
 
 
 @pytest.mark.django_db

--- a/racedbapp/view_event.py
+++ b/racedbapp/view_event.py
@@ -113,7 +113,10 @@ def index(request, year, race_slug, distance_slug, sequel_slug=None):
     series = []
     all_series = Series.objects.all().order_by("year")
     for s in all_series:
-        if event.id in [int(x.strip()) for x in s.event_ids.split(",")]:
+        event_ids = [
+            int(x.strip()) for x in s.event_ids.split(",") if x.strip().isdigit()
+        ]
+        if event.id in event_ids:
             series.append(s)
     process_post(request)
     race_logo_slug = utils.get_race_logo_slug(event.race.slug)


### PR DESCRIPTION
## What happened

After the age-grade feature (#284) merged and deployed, **all event pages and the Series admin started returning 500s** in production:

```
django.db.utils.ProgrammingError: column racedbapp_series.age_grade_enabled does not exist
```

## Root cause

The deploy automation **never runs `migrate`**. The Helm chart (`deployment-web.yaml`) only starts gunicorn, and `autoupgrade.sh`/`upgrade.sh` do `helm upgrade` + `clear_cache` — but nothing applies migrations. So #284 shipped code that selects `Series.age_grade_enabled`, but `0079_series_age_grade_enabled` was never applied to the prod DB. Every query against the `Series` model then 500s — which is why both the event pages (`view_event.py` does `Series.objects.all()`) and the Series admin (`list_display` includes the field) broke.

## Fix

1. **`deploy/helm/templates/job-migrate.yaml`** — a Helm `pre-upgrade,pre-install` hook Job that runs `python manage.py migrate --noinput` **before** new pods roll out, using the deploy image tag and the same env/secrets as the web pod. Closes the "deploy without migrate" gap permanently. Because `upgrade.sh` runs `helm upgrade --wait` under `set -e`, a failed migration now aborts the rollout (old pods keep serving) instead of shipping code against a bad schema.
2. **`racedbapp/view_event.py`** — defensive hardening: skip blank/non-numeric tokens when parsing `Series.event_ids`, so a single malformed series row can't 500 every event page. (Separate latent bug surfaced while debugging.)

## How this restores prod

Merging to `main` builds a new tagged image; the server's `autoupgrade` cron picks it up and runs `helm upgrade`, which now runs the migrate hook → `age_grade_enabled` column is created → 500s clear. No manual kubectl required.

## Verification (local Docker)

- Reproduced the exact prod 500 on both the event page **and** the Series admin by reversing `0079` (column missing) — confirmed `ProgrammingError: column ... does not exist`.
- Re-applying the migration returned both to HTTP 200.
- Reproduced the separate `event_ids` crash with a trailing-comma value; confirmed the hardening fixes it while legit series still link correctly.
- `helm lint` passes and `helm template` renders the Job correctly against `values-rrw.yaml`.
- All 17 `test_view_event.py` tests pass.

