### PR TITLE
fix: relay pages 500 — resolve race logo slug from flattened view-model

### DIFF
--- a/racedbapp/templatetags/racedbapp_extras.py
+++ b/racedbapp/templatetags/racedbapp_extras.py
@@ -115,5 +115,9 @@ def get_default_record_distance_slug(string):
 def event_logo(event):
     if getattr(event, "custom_logo_url", None):
         return event.custom_logo_url
-    safe_slug = get_race_logo_slug(event.race.slug)
+    # Some views (e.g. relay) pass a flattened view-model without a `.race`
+    # relation but with a `race_slug`; fall back to that before giving up.
+    race = getattr(event, "race", None)
+    slug = race.slug if race else getattr(event, "race_slug", None)
+    safe_slug = get_race_logo_slug(slug)
     return static(f"race_logos/{safe_slug}.png")

--- a/racedbapp/tests/templatetags/test_racedbapp_extras.py
+++ b/racedbapp/tests/templatetags/test_racedbapp_extras.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -53,3 +54,22 @@ def test_event_logo_prefers_custom_logo_url(create_event):
     event.custom_logo_url = "http://example.com/logo.png"
     with patch("racedbapp.shared.utils.Path.is_file", return_value=False):
         assert event_logo(event) == "http://example.com/logo.png"
+
+
+def test_event_logo_uses_race_slug_for_relay_view_model():
+    # The relay view passes a flattened EventV with `race_slug` and no `.race`.
+    event = SimpleNamespace(race_slug="test-race-a")
+    with patch("racedbapp.shared.utils.Path.is_file", return_value=True):
+        assert event_logo(event) == "/static/race_logos/test-race-a.png"
+
+
+def test_event_logo_relay_view_model_falls_back_when_file_missing():
+    event = SimpleNamespace(race_slug="does-not-exist")
+    with patch("racedbapp.shared.utils.Path.is_file", return_value=False):
+        assert event_logo(event) == "/static/race_logos/rw-race-logo.png"
+
+
+def test_event_logo_falls_back_when_no_race_info():
+    # Neither a `.race` relation nor a `race_slug` attribute is present.
+    event = SimpleNamespace()
+    assert event_logo(event) == "/static/race_logos/rw-race-logo.png"

--- a/racedbapp/tests/views/test_view_relay.py
+++ b/racedbapp/tests/views/test_view_relay.py
@@ -1,0 +1,40 @@
+import datetime
+
+import pytest
+from rest_framework.test import APIClient
+
+from racedbapp.models import Relay
+
+
+@pytest.mark.django_db
+def test_relay_index_renders(create_event, create_result):
+    """End-to-end smoke test for the relay view.
+
+    Regression guard for the relay 500: `event_logo` accessed
+    `event.race.slug` on the relay view's flattened ``EventV`` (which has a
+    ``race_slug`` but no ``.race``). See ``event_logo`` in
+    ``racedbapp/templatetags/racedbapp_extras.py``.
+    """
+    event = create_event(name_suffix="relay")
+    # Two individual finishers whose places the relay legs reference; the relay
+    # view joins Relay.place back to these Result rows by "{year}-{place}".
+    create_result(event=event, name_suffix="leg1", place=1)
+    create_result(event=event, name_suffix="leg2", place=2)
+    team_time = datetime.timedelta(minutes=10)
+    for leg, place in ((1, 1), (2, 2)):
+        Relay.objects.create(
+            event=event,
+            place=place,
+            relay_team="Test Relay Team",
+            relay_team_place=1,
+            relay_team_time=team_time,
+            relay_leg=leg,
+        )
+
+    client = APIClient()
+    url = f"/relay/{event.date.year}/{event.race.slug}/{event.distance.slug}/"
+    response = client.get(url)
+
+    assert response.status_code == 200
+    # The EventV has no matching logo file, so it falls back via event_logo.
+    assert b"race_logos/rw-race-logo.png" in response.content


### PR DESCRIPTION
## Problem

Relay pages were returning HTTP 500, e.g.:

- https://racedb.runwaterloo.com/relay/2026/waterloo-classic/10-km/
- https://racedb.runwaterloo.com/relay/2025/member-relay/2_5-km/

```
AttributeError: 'EventV' object has no attribute 'race'
  at racedbapp/templatetags/racedbapp_extras.py, in event_logo
  Raised during: racedbapp.view_relay.index
```

The `event_logo` template tag does `event.race.slug`, but the relay view passes a flattened `EventV` view-model (`view_relay.py`) that exposes `race_slug` and has no `.race` relation. `relay.html` calls `{% event_logo event %}`, so it crashes.

## Root cause (not a recent regression )

This is a **latent bug from PR #77** ("add custom event logo functionality"), which introduced `event_logo` accessing `event.race.slug` and switched `relay.html` from the working `race_logo_slug` context variable to `{% event_logo event %}`. Before that, relay rendered its logo from the separately-passed slug.

PR #279 wrapped the same `event.race.slug` access with `get_race_logo_slug(...)` — it neither introduced nor fixed the crash; it just shifted the failing line. Relay pages are seasonal/low-traffic, so the breakage went unnoticed until now.

## Fix

`event_logo` now resolves the slug from either object shape:

```python
race = getattr(event, "race", None)
slug = race.slug if race else getattr(event, "race_slug", None)
safe_slug = get_race_logo_slug(slug)
```

- `view_event`'s namedtuple keeps its real `.race` → unchanged behavior.
- relay's `EventV` falls back to `race_slug` → renders the default race logo, no crash.
- Neither present → `get_race_logo_slug(None)` → `rw-race-logo`.

The custom-logo branch is untouched, so **relay custom-logo behavior is unchanged** (relays still don't display custom logos, exactly as today).

## Tests

- 3 unit tests for `event_logo` against relay-style objects (slug present, file-missing fallback, no-race-info fallback).
- New end-to-end smoke test `test_view_relay.py`: builds an event + finishers + relay legs, asserts `200`, and asserts the `rw-race-logo.png` fallback renders. Reverting the fix makes this test fail with the exact production traceback; restoring it passes.