### PR TITLE
fix: interpolate open standards linearly in distance, not log-distance

### DIFF
--- a/racedbapp/shared/agegrade.py
+++ b/racedbapp/shared/agegrade.py
@@ -15,9 +15,13 @@ Distance resolution:
     * Road wins where a distance exists on both surfaces. The track tables apply
       only below the 1-mile (1609.344 m) road floor.
     * A distance matching a committed anchor uses that anchor's factor directly.
-    * Otherwise the factor (and open standard) are interpolated between the two
-      nearest anchors using **log-distance weighting** ``u = ln(d/d_lo) /
-      ln(d_hi/d_lo)`` and ``age_standard = open_interp / factor_interp``.
+    * Otherwise the standard is interpolated between the two nearest anchors,
+      each quantity on the scale it actually varies with: the per-age
+      **factor** with log-distance weighting ``u = ln(d/d_lo) / ln(d_hi/d_lo)``
+      (Alan Jones' scheme — factors depend on relative distance), and the
+      **open standard** with linear-distance weighting (time grows ~linearly
+      with absolute distance; log weighting overstates it by up to ~17% in the
+      wide mile→5 km gap). Then ``age_standard = open_interp / factor_interp``.
     * A distance outside the committed-anchor span raises ``ValueError``.
 """
 
@@ -146,8 +150,11 @@ def standard_seconds(distance_m, gender, age, default_gender_table=DEFAULT_GENDE
             surface.factor_at(table_gender, d_lo, age) * (1 - u)
             + surface.factor_at(table_gender, d_hi, age) * u
         )
+        # Time scales ~linearly with distance, so the open standard must use a
+        # linear-distance weight, not the factor's log-distance weight.
+        v = (distance_m - d_lo) / (d_hi - d_lo)
         open_seconds = (
-            surface.open[(table_gender, d_lo)] * (1 - u) + surface.open[(table_gender, d_hi)] * u
+            surface.open[(table_gender, d_lo)] * (1 - v) + surface.open[(table_gender, d_hi)] * v
         )
     return open_seconds / factor
 

--- a/racedbapp/shared/agegrade_data/README.md
+++ b/racedbapp/shared/agegrade_data/README.md
@@ -28,10 +28,17 @@ age (factor `1.0`) resolves to the committed open standard with no sentinel row.
 - Factors are four decimal places, matching the published tables.
 - Road wins where a distance exists on both surfaces; the track tables apply
   only **below the 1-mile (1609.344 m) road floor**.
-- Non-anchor distances are resolved by **log-distance interpolation of the
-  factor** between the two nearest anchors — Alan Jones' verified 2025 scheme,
-  which reproduces his published per-distance tables to ≈0.00005 (vs ≈0.0008 for
-  linear-distance interpolation).
+- Non-anchor distances are resolved by interpolating between the two nearest
+  anchors, each quantity on the scale it varies with:
+  - The per-age **factor** uses **log-distance interpolation** — Alan Jones'
+    verified 2025 scheme, which reproduces his published per-distance tables to
+    ≈0.00005 (vs ≈0.0008 for linear-distance interpolation).
+  - The **open standard** uses **linear-distance interpolation** — time grows
+    ~linearly with distance, so log-distance weighting overstates interpolated
+    times (by ~17% at 3 km in the wide mile→5 km gap, the bug behind
+    inflated e-60 2026 age grades). Linear-distance reconstructs each committed
+    sub-marathon anchor from its neighbours to within ~1.2%, and matches
+    independent calculators (runbundle) on the interpolated open standard.
 
 ## Sources
 

--- a/racedbapp/tests/shared/test_agegrade.py
+++ b/racedbapp/tests/shared/test_agegrade.py
@@ -1,10 +1,13 @@
+import csv
 import math
+import os
 
 import pytest
 
 from racedbapp.shared import agegrade
 
 MILE_M = 1609.344
+MARATHON_M = 42195.0
 
 # Published open-class standards (seconds) from the committed reference data.
 OPEN_5K_M = 769.0  # 12:49
@@ -21,6 +24,23 @@ def _factor(distance_m, gender, age):
     return agegrade.standard_seconds(distance_m, gender, None) / agegrade.standard_seconds(
         distance_m, gender, age
     )
+
+
+def _committed_road_opens(gender):
+    """Committed road open standards as ``[(distance_m, open_seconds), ...]``.
+
+    Read straight from the versioned CSV so interpolation tests compare the
+    implementation against the committed ground truth, never against the
+    implementation's own output.
+    """
+    path = os.path.join(agegrade.DATA_DIR, "road_open_standards.csv")
+    with open(path, newline="") as fh:
+        rows = [
+            (float(row["distance_m"]), float(row["open_seconds"]))
+            for row in csv.DictReader(fh)
+            if row["gender"] == gender
+        ]
+    return sorted(rows)
 
 
 # --------------------------------------------------------------------------- #
@@ -76,18 +96,61 @@ def test_log_distance_interpolation_reproduces_published_intermediate():
     assert abs(lin_interp - published_8k) > 1e-4  # linear-distance is worse
 
 
-def test_api_interpolates_between_bracketing_anchors():
-    # 125 km is not an anchor; the 100 km and 150 km anchors are adjacent (no
-    # committed anchor lies between them), so they bracket it.
-    distance = 125000.0
-    d_lo, d_hi = 100000.0, 150000.0
-    o_lo = agegrade.standard_seconds(d_lo, "M", None)
-    o_hi = agegrade.standard_seconds(d_hi, "M", None)
-    f_lo = _factor(d_lo, "M", 50)
-    f_hi = _factor(d_hi, "M", 50)
-    u = math.log(distance / d_lo) / math.log(d_hi / d_lo)
-    expected = (o_lo * (1 - u) + o_hi * u) / (f_lo * (1 - u) + f_hi * u)
-    assert agegrade.standard_seconds(distance, "M", 50) == pytest.approx(expected, rel=1e-9)
+# --------------------------------------------------------------------------- #
+# Open-standard interpolation, validated against ground truth
+#
+# These tests never compare the implementation against its own formula. The
+# ground truths are (a) the committed anchor standards themselves, (b) the
+# physical shape of world-record performances (pace slows as distance grows),
+# and (c) an independent calculator (runbundle.com) built on the same
+# Alan Jones 2025 tables.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("gender", ["M", "F"])
+def test_open_interpolation_reconstructs_committed_anchors(gender):
+    # Leave-one-out: drop each sub-marathon interior anchor and predict its
+    # committed open standard by linear-distance interpolation between its
+    # neighbours. Worst case is ~1.2% (M marathon from 30 km and 50 km); the
+    # log-distance weighting this replaced missed the M 5 km anchor by +8%.
+    opens = _committed_road_opens(gender)
+    for (d_lo, o_lo), (d_mid, o_mid), (d_hi, o_hi) in zip(opens, opens[1:], opens[2:]):
+        if d_mid > MARATHON_M:
+            break  # ultra anchors are too sparse for a meaningful bound
+        v = (d_mid - d_lo) / (d_hi - d_lo)
+        predicted = o_lo * (1 - v) + o_hi * v
+        assert predicted == pytest.approx(o_mid, rel=0.015), (gender, d_mid)
+
+
+@pytest.mark.parametrize("gender", ["M", "F"])
+def test_open_standard_pace_never_speeds_up_with_distance(gender):
+    # World-best pace per km only slows as the distance grows. The log-distance
+    # bug violated this: it gave a 3 km open standard of 8:45 (2:55/km) versus
+    # 2:34/km at 5 km. Sample every anchor and every inter-anchor midpoint.
+    anchors = [d for d, _ in _committed_road_opens(gender)]
+    samples = sorted(
+        anchors + [math.sqrt(lo * hi) for lo, hi in zip(anchors, anchors[1:])]
+    )
+    paces = [agegrade.standard_seconds(d, gender, None) / d for d in samples]
+    for (d, slower), (d_prev, faster) in zip(
+        zip(samples[1:], paces[1:]), zip(samples, paces)
+    ):
+        assert slower >= faster * (1 - 1e-9), (gender, d_prev, d)
+
+
+def test_3k_open_standard_matches_independent_calculator():
+    # runbundle.com/tools/age-grading-calculator (same Alan Jones 2025 road
+    # tables) reports a 7:29.3 (449.3 s) open-class standard for 3 km road,
+    # consistent with the 7:20.67 track 3000 m world record. The log-distance
+    # bug produced 8:44.8 here.
+    assert agegrade.standard_seconds(3000, "M", None) == pytest.approx(449.3, abs=1.0)
+
+
+def test_3k_age_grade_matches_independent_calculator():
+    # Regression for the e-60 2026 series: M68 running 3 km in 11:50 scored
+    # 99.37 under the log-distance bug. runbundle reports 85.35 for the same
+    # inputs; we get ~85.1 (runbundle interpolates the age factor linearly,
+    # we keep Jones' log-distance factor scheme — a ~0.3 point difference).
+    grade = agegrade.age_grade(3000, "M", 68, 11 * 60 + 50)
+    assert 84.0 < grade < 86.0
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

The e-60 2026 age-grade standings showed a 68-year-old male's 11:50 3 km at **99.37** — a world-record-level score for a mid-80s performance. runbundle's calculator (built on the same Alan Jones 2025 tables) gives **85.35** for identical inputs.

## Root cause

For distances not in the reference tables (3 km falls between the 1-mile and 5 km anchors), `standard_seconds()` interpolated both the age factor **and** the open-class standard with the same log-distance weight `u = ln(d/d_lo)/ln(d_hi/d_lo)`.

That weight is correct for factors — it's Alan Jones' verified scheme, and factors vary with *relative* distance — but wrong for times, which grow ~linearly with *absolute* distance. Log weighting treats 3 km as 55% of the way from the mile to 5 km instead of 41%, producing an implied open 3 km standard of **8:44.8** (the real-world figure is ~7:20–7:29). Every 3 km age grade was graded against that fictional slow standard, inflating it by ~17%.

It slipped through because:
- the mile→5 km gap is by far the widest anchor ratio in the table (3.11×) — everywhere else the error is under ~2%, and this was likely the first sub-5 km road result to hit the code;
- the only test of interpolated open standards computed its expected value with the implementation's own formula, so it validated the code against itself.

## Fix

Interpolate the open standard with a linear-distance weight; keep log-distance weighting for the factor. The M68 case: 99.37 → **85.08** (runbundle: 85.35; the residue is the factor scheme, where ours tracks Jones' published tables slightly more closely).

Age grades are computed live in the view, so results pages correct themselves on deploy — no migration or backfill.

## Tests

Replaced the self-referential test with checks grounded outside the implementation, each verified to fail under the old scheme:
- **Leave-one-out anchor reconstruction** (M/F): each sub-marathon anchor's committed open standard is reproduced from its neighbours to ≤1.2% (the log scheme misses the M 5 km anchor by +8%).
- **Pace monotonicity** (M/F): open-standard pace per km never speeds up as distance grows, at every anchor and midpoint (the bug claimed 2:55/km at 3 km vs 2:34/km at 5 km).
- **Independent calculator cross-checks**: 3 km open standard = 449.3 s ± 1 and the M68/11:50 case grades 84–86, both pinned against runbundle.

Full suite: 201 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)